### PR TITLE
Fix recipe filtering without pandas

### DIFF
--- a/macro-app-api/README.md
+++ b/macro-app-api/README.md
@@ -69,6 +69,11 @@ Authorization: Bearer <token>
 GET /api/search?q=chicken&min_protein=20
 ```
 
+#### Filter Recipes by Calories per Gram of Protein
+```http
+GET /api/recipes/filter
+```
+
 ### Shopping List
 
 #### Generate Instacart List

--- a/macro-app-api/pages/api/recipes/filter.ts
+++ b/macro-app-api/pages/api/recipes/filter.ts
@@ -1,0 +1,19 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { filterRecipesByCalorieProteinRatio } from '../../../lib/supabase';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const recipes = await filterRecipesByCalorieProteinRatio();
+    return res.status(200).json({ success: true, recipes });
+  } catch (error) {
+    console.error('Error filtering recipes:', error);
+    return res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+}


### PR DESCRIPTION
## Summary
- fix recipe filtering endpoint
- remove pandas dependency and compute nutrition in DataLoader
- update search filters to use new nutrition data
- add Next.js API route for recipe filtering

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f3ef432b88323b586ad1044804fc0