### PR TITLE
Fix recipe search URL

### DIFF
--- a/frontend/lib/services/api_service.dart
+++ b/frontend/lib/services/api_service.dart
@@ -255,7 +255,7 @@ class ApiService {
     
     if (kIsWeb) {
       final response = await _httpClient.get(
-        Uri.parse('$baseUrl/api/recipes/search').replace(queryParameters: {'q': query}),
+        Uri.parse('$baseUrl/api/search').replace(queryParameters: {'q': query}),
         headers: headers,
       );
       
@@ -266,7 +266,7 @@ class ApiService {
       }
     } else {
       final response = await _dio.get(
-        '/api/recipes/search',
+        '/api/search',
         options: Options(
           headers: headers,
           validateStatus: (status) => status! < 500,


### PR DESCRIPTION
## Summary
- fix search endpoint in Flutter API client

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840bbb3c0d88323b6818c72132a6111