### PR TITLE
Use x-callback-url scheme for Apple Notes

### DIFF
--- a/frontend/lib/screens/recipe_details_screen.dart
+++ b/frontend/lib/screens/recipe_details_screen.dart
@@ -103,37 +103,27 @@ class _RecipeDetailsScreenState extends State<RecipeDetailsScreen>
         return '☐ $amount $unit $name';
       }).join('\n');
 
-      // Create a URL scheme for Notes app with title
+      // Create a URL scheme for Notes app using the x-callback-url API
       final noteTitle = '$recipeName - Grocery List';
-      final notesUrl = Uri(
+      final notesUri = Uri(
         scheme: 'mobilenotes',
-        host: 'create',
+        host: 'x-callback-url',
+        path: 'create',
         queryParameters: {
           'title': noteTitle,
           'text': noteContent,
         },
-      ).toString();
-      
-      if (await canLaunchUrl(Uri.parse(notesUrl))) {
-        await launchUrl(Uri.parse(notesUrl));
+      );
+
+      if (await canLaunchUrl(notesUri)) {
+        await launchUrl(notesUri);
       } else {
-        // Try alternative URL scheme
-        final alternativeUrl = Uri(
-          scheme: 'notes',
-          host: 'create',
-          queryParameters: {
-            'title': noteTitle,
-            'text': noteContent,
-          },
-        ).toString();
-        
-        if (await canLaunchUrl(Uri.parse(alternativeUrl))) {
-          await launchUrl(Uri.parse(alternativeUrl));
-        } else {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Could not open Notes app')),
-          );
-        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Unable to open Apple Notes. Please ensure the app is installed.'),
+          ),
+        );
       }
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- use the `mobilenotes://x-callback-url/create` deep link for creating Apple Notes
- show clearer error message if Notes can't open

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bbb4318483239405b54c6b07ee20