### PR TITLE
Add iOS Podfile and docs for TestFlight build

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ API_BASE_URL=your_api_base_url
 ```bash
 flutter run
 ```
+6. Build for iOS before archiving
+```bash
+flutter build ios --release
+cd ios && pod install
+```
+Then open `Runner.xcworkspace` in Xcode and archive the app.
+
 
 ## Contributing
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/frontend/ios/Podfile
+++ b/frontend/ios/Podfile
@@ -1,0 +1,37 @@
+# CocoaPods podfile for Flutter iOS project
+platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. Run 'flutter build ios' first."
+  end
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    match = line.match(/FLUTTER_ROOT=(.*)/)
+    return match[1].strip if match
+  end
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  flutter_post_install(installer.pods_project)
+end


### PR DESCRIPTION
## Summary
- add a default `Podfile` to the iOS project so CocoaPods installs required Flutter plugins
- document iOS build steps in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68446bed92e883239b901413764f331f