### PR TITLE
Fix saved recipes features

### DIFF
--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -50,13 +50,13 @@ class _HomeScreenState extends State<HomeScreen> {
       // Load hearted recipes from Supabase
       final heartedRecipesData = await SupabaseService.getHeartedRecipes(userId);
       
-      // Load custom lists from Supabase
+      // Load custom lists and their recipes from Supabase
       final customListsData = await SupabaseService.getCustomLists(userId);
-      
-      // Convert custom lists to the expected format
       final Map<String, List<Map<String, dynamic>>> formattedLists = {};
       for (var list in customListsData) {
-        formattedLists[list['name']] = [];
+        final listRecipes = await SupabaseService.getRecipesForList(list['id']);
+        formattedLists[list['name']] =
+            listRecipes.map((r) => r['recipes'] as Map<String, dynamic>).toList();
       }
       
       setState(() {
@@ -115,10 +115,13 @@ class _HomeScreenState extends State<HomeScreen> {
       body: _pages[_selectedIndex],
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _selectedIndex,
-        onTap: (index) {
+        onTap: (index) async {
           setState(() {
             _selectedIndex = index;
           });
+          if (index == 2) {
+            await _loadUserData();
+          }
         },
         backgroundColor: Colors.black,
         selectedItemColor: Colors.deepOrange,

--- a/frontend/lib/screens/recipe_details_screen.dart
+++ b/frontend/lib/screens/recipe_details_screen.dart
@@ -25,10 +25,21 @@ class _RecipeDetailsScreenState extends State<RecipeDetailsScreen>
   bool _isHearted = false; // Track if the recipe is hearted
   late AnimationController _animationController;
 
+  Future<void> _checkHeartedState() async {
+    final userId = await AuthService.getUserId();
+    if (userId != null) {
+      final hearted = await SupabaseService.isRecipeHearted(userId, widget.recipeId);
+      if (mounted) {
+        setState(() => _isHearted = hearted);
+      }
+    }
+  }
+
   @override
   void initState() {
     super.initState();
     recipeDetails = ApiService.getRecipeDetails(widget.recipeId);
+    _checkHeartedState();
     _animationController = AnimationController(
       vsync: this,
       duration: Duration(milliseconds: 500),
@@ -232,7 +243,7 @@ class _RecipeDetailsScreenState extends State<RecipeDetailsScreen>
           IconButton(
             icon: Icon(Icons.add, color: Colors.white),
             onPressed: () {
-              _showSaveToListDialog(context, "Recipe Name", {}); // Replace with actual recipe name and custom lists
+              _showSaveToListDialog(context);
             },
           ),
         ],
@@ -741,7 +752,7 @@ class _RecipeDetailsScreenState extends State<RecipeDetailsScreen>
     );
   }
 
-  void _showSaveToListDialog(BuildContext context, String recipeName, Map<String, List<Map<String, dynamic>>> customLists) async {
+  void _showSaveToListDialog(BuildContext context) async {
     try {
       final userId = await AuthService.getUserId();
       if (userId == null) {
@@ -787,13 +798,6 @@ class _RecipeDetailsScreenState extends State<RecipeDetailsScreen>
                         listId: list['id'],
                         recipeId: recipeId,
                       );
-                      
-                      setState(() {
-                        if (!customLists.containsKey(list['name'])) {
-                          customLists[list['name']] = [];
-                        }
-                        customLists[list['name']]!.add(recipe['recipe']);
-                      });
                       
                       if (!context.mounted) return;
                       Navigator.pop(context);

--- a/frontend/lib/services/supabase_service.dart
+++ b/frontend/lib/services/supabase_service.dart
@@ -291,4 +291,45 @@ CREATE TABLE users (
       return false;
     }
   }
-} 
+
+  static Future<bool> isRecipeHearted(String userId, int recipeId) async {
+    if (!_isInitialized) {
+      await initialize();
+    }
+
+    try {
+      final user = await getUserByPhone(userId);
+      if (user == null) return false;
+
+      final result = await client
+          .from('hearted_recipes')
+          .select('id')
+          .eq('user_id', user['id'])
+          .eq('recipe_id', recipeId)
+          .maybeSingle();
+
+      return result != null;
+    } catch (e) {
+      print('Error checking hearted state: $e');
+      return false;
+    }
+  }
+
+  static Future<List<Map<String, dynamic>>> getRecipesForList(String listId) async {
+    if (!_isInitialized) {
+      await initialize();
+    }
+
+    try {
+      final response = await client
+          .from('list_recipes')
+          .select('recipe_id, recipes(*)')
+          .eq('list_id', listId);
+
+      return List<Map<String, dynamic>>.from(response);
+    } catch (e) {
+      print('Error getting list recipes: $e');
+      return [];
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- fetch recipes for each custom list
- reload user data when navigating to profile
- check hearted state of recipes and update icon
- show add-to-list dialog without placeholder args
- add helper methods in SupabaseService for list recipes and heart checks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68447ab3f17483238116e407a4214877