### PR TITLE
Ensure env vars in release build

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ cd ios && pod install
 ```
 Then open `Runner.xcworkspace` in Xcode and archive the app.
 
+The `.env` file is bundled with the Flutter app, so its values are available in
+release builds. Ensure `frontend/.env` is present before running `flutter build`
+to avoid missing environment variables on TestFlight.
+
 ### Backend Environment Variables
 
 Create a `.env` file in `macro-app-api` with the following variables:

--- a/frontend/lib/config/app_config.dart
+++ b/frontend/lib/config/app_config.dart
@@ -8,26 +8,22 @@ class AppConfig {
   factory AppConfig() => _instance;
   AppConfig._internal();
 
-  // Configuration values
-  late final String supabaseUrl;
-  late final String supabaseAnonKey;
-  late final String apiBaseUrl;
+  // Accessors for environment values
+  String get supabaseUrl => dotenv.env['SUPABASE_URL'] ?? '';
+  String get supabaseAnonKey => dotenv.env['SUPABASE_ANON_KEY'] ?? '';
+  String get apiBaseUrl => dotenv.env['API_BASE_URL'] ?? '';
   
   // Initialize configuration based on environment
   Future<void> initialize() async {
-    if (kDebugMode) {
-      // In debug mode, load from .env file
-      await dotenv.load(fileName: ".env");
-    }
-    
-    // Use environment variables in both debug and production
-    supabaseUrl = dotenv.env['SUPABASE_URL'] ?? '';
-    supabaseAnonKey = dotenv.env['SUPABASE_ANON_KEY'] ?? '';
-    apiBaseUrl = dotenv.env['API_BASE_URL'] ?? '';
+    // Load from .env file in all build modes
+    await dotenv.load(fileName: ".env");
     
     // Validate required configuration
-    if (supabaseUrl.isEmpty || supabaseAnonKey.isEmpty || apiBaseUrl.isEmpty) {
-      throw Exception('Missing required environment variables. Please check your configuration.');
+    if (supabaseUrl.isEmpty ||
+        supabaseAnonKey.isEmpty ||
+        apiBaseUrl.isEmpty) {
+      throw Exception(
+          'Missing required environment variables. Please check your configuration.');
     }
   }
   

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -15,13 +15,7 @@ import 'services/api_service.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   
-  // Load environment variables
-  await dotenv.load(fileName: ".env");
-  print('Environment variables loaded:');
-  print('API_BASE_URL: ${dotenv.env['API_BASE_URL']}');
-  print('All env vars: ${dotenv.env}');
-  
-  // Initialize app configuration
+  // Initialize app configuration (loads environment variables)
   final appConfig = AppConfig();
   await appConfig.initialize();
   


### PR DESCRIPTION
## Summary
- load `.env` in AppConfig for all build modes
- simplify `AppConfig` by exposing env variables through getters
- remove redundant env loading in `main.dart`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68476076f10c83238d05945c1ae316b9