### PR TITLE
Migrate Flutter env config to dart define

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,25 +70,24 @@ cd frontend
 flutter pub get
 ```
 
-4. Create a .env file in the frontend directory with the following variables:
-```
-API_BASE_URL=your_api_base_url
+4. Provide configuration values using `--dart-define` when running or building.
+   Example:
+```bash
+flutter run \
+  --dart-define=API_BASE_URL=https://api.example.com \
+  --dart-define=SUPABASE_URL=your_supabase_url \
+  --dart-define=SUPABASE_ANON_KEY=your_supabase_anon_key
 ```
 
-5. Run the app
+5. Build for iOS before archiving
 ```bash
-flutter run
-```
-6. Build for iOS before archiving
-```bash
-flutter build ios --release
+flutter build ios --release \
+  --dart-define=API_BASE_URL=https://api.example.com \
+  --dart-define=SUPABASE_URL=your_supabase_url \
+  --dart-define=SUPABASE_ANON_KEY=your_supabase_anon_key
 cd ios && pod install
 ```
 Then open `Runner.xcworkspace` in Xcode and archive the app.
-
-The `.env` file is bundled with the Flutter app, so its values are available in
-release builds. Ensure `frontend/.env` is present before running `flutter build`
-to avoid missing environment variables on TestFlight.
 
 ### Backend Environment Variables
 
@@ -108,13 +107,8 @@ UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 ```
 
-For the Flutter app, create `frontend/.env` with:
-
-```
-API_BASE_URL=your_api_base_url
-```
-
-A sample configuration is provided in `.env.example`.
+For the Flutter app, pass values via `--dart-define` as shown above. A sample set
+of variables is listed in `.env.example` for reference.
 
 
 ## Contributing

--- a/frontend/lib/config/app_config.dart
+++ b/frontend/lib/config/app_config.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart' show kDebugMode;
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 /// A class to manage application configuration across different environments
 class AppConfig {
@@ -8,25 +7,21 @@ class AppConfig {
   factory AppConfig() => _instance;
   AppConfig._internal();
 
-  // Accessors for environment values
-  String get supabaseUrl => dotenv.env['SUPABASE_URL'] ?? '';
-  String get supabaseAnonKey => dotenv.env['SUPABASE_ANON_KEY'] ?? '';
-  String get apiBaseUrl => dotenv.env['API_BASE_URL'] ?? '';
-  
-  // Initialize configuration based on environment
+  // Accessors for compile-time environment values
+  String get supabaseUrl => const String.fromEnvironment('SUPABASE_URL');
+  String get supabaseAnonKey => const String.fromEnvironment('SUPABASE_ANON_KEY');
+  String get apiBaseUrl => const String.fromEnvironment('API_BASE_URL');
+
+  // Validate configuration; called during startup
   Future<void> initialize() async {
-    // Load from .env file in all build modes
-    await dotenv.load(fileName: ".env");
-    
-    // Validate required configuration
     if (supabaseUrl.isEmpty ||
         supabaseAnonKey.isEmpty ||
         apiBaseUrl.isEmpty) {
       throw Exception(
-          'Missing required environment variables. Please check your configuration.');
+          'Missing required --dart-define values. Please provide SUPABASE_URL, SUPABASE_ANON_KEY and API_BASE_URL.');
     }
   }
-  
+
   // Helper method to check if we're in debug mode
   bool get isDebugMode => kDebugMode;
-} 
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:provider/provider.dart' as provider;
 import 'package:google_fonts/google_fonts.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'config/app_config.dart';
 import 'screens/home_screen.dart';
 import 'services/auth_service.dart';

--- a/frontend/lib/services/api_client.dart
+++ b/frontend/lib/services/api_client.dart
@@ -1,16 +1,14 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter/foundation.dart';
 
 class ApiClient {
-  static final String baseUrl = dotenv.env['API_BASE_URL']!;
+  static final String baseUrl = const String.fromEnvironment('API_BASE_URL');
 
   static void _logEnvVars() {
     if (kDebugMode) {
       print('ApiClient initialization:');
-      print('API_BASE_URL: ${dotenv.env['API_BASE_URL']}');
-      print('All env vars: ${dotenv.env}');
+      print('API_BASE_URL: $baseUrl');
     }
   }
 

--- a/frontend/lib/services/api_service.dart
+++ b/frontend/lib/services/api_service.dart
@@ -3,11 +3,12 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter/foundation.dart' show kIsWeb, kDebugMode;
-import 'package:flutter_dotenv/flutter_dotenv.dart';
+import '../config/app_config.dart';
 import 'auth_service.dart';
 
 class ApiService {
-  static final String baseUrl = dotenv.env['API_BASE_URL']!.replaceAll('/api', '');
+  static final String baseUrl =
+      const String.fromEnvironment('API_BASE_URL').replaceAll('/api', '');
   static late final Dio _dio;
   static late final http.Client _httpClient;
 
@@ -56,9 +57,7 @@ class ApiService {
   static void _logEnvVars() {
     if (kDebugMode) {
       print('ApiService initialization:');
-      print('API_BASE_URL: ${dotenv.env['API_BASE_URL']}');
-      print('Base URL after processing: $baseUrl');
-      print('All env vars: ${dotenv.env}');
+      print('API_BASE_URL: $baseUrl');
       print('Is Web: $kIsWeb');
     }
   }

--- a/frontend/lib/services/auth_service.dart
+++ b/frontend/lib/services/auth_service.dart
@@ -1,14 +1,13 @@
 import 'dart:convert';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter/material.dart';
 import '../providers/auth_provider.dart';
 import 'api_client.dart';
 
 class AuthService {
-  static final String baseUrl = dotenv.env['API_BASE_URL']!;
+  static final String baseUrl = const String.fromEnvironment('API_BASE_URL');
   static const String _tokenKey = 'auth_token';
   static const String _userIdKey = 'user_id';
   static const String _userNameKey = 'user_name';

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -174,14 +174,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
-  flutter_dotenv:
-    dependency: "direct main"
-    description:
-      name: flutter_dotenv
-      sha256: b7c7be5cd9f6ef7a78429cabd2774d3c4af50e79cb2b7593e3d5d763ef95c61b
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.2.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -38,7 +38,6 @@ dependencies:
   http: ^1.1.0  # API requests
   provider: ^6.0.5  # State management
   google_fonts: ^6.1.0  # Custom fonts
-  flutter_dotenv: ^5.1.0  # Environment variables
   lottie: ^2.6.0
   cached_network_image: ^3.2.3
   shimmer: ^3.0.0


### PR DESCRIPTION
## Summary
- refactor frontend to remove flutter_dotenv
- use compile-time `String.fromEnvironment` values
- update README with new `--dart-define` instructions

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b1190c108323bd49c4b563f6763f